### PR TITLE
Create a static page with a Three.js example

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,10 @@ const express = require('express')
 const app = express()
 const port = 3000
 
+app.use(express.static('public'));
+
 app.get('/', (req, res) => {
-  res.send('Hello World!')
+  res.sendFile(__dirname + '/public/index.html');
 })
 
 app.listen(port, () => {

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Three.js Example</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+    <script src="main.js"></script>
+</head>
+<body>
+    <div id="container"></div>
+</body>
+</html>

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,30 @@
+import * as THREE from 'three';
+
+let scene, camera, renderer, cube;
+
+function init() {
+    scene = new THREE.Scene();
+    camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+    renderer = new THREE.WebGLRenderer();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    document.getElementById('container').appendChild(renderer.domElement);
+
+    const geometry = new THREE.BoxGeometry();
+    const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
+    cube = new THREE.Mesh(geometry, material);
+    scene.add(cube);
+
+    camera.position.z = 5;
+}
+
+function animate() {
+    requestAnimationFrame(animate);
+
+    cube.rotation.x += 0.01;
+    cube.rotation.y += 0.01;
+
+    renderer.render(scene, camera);
+}
+
+init();
+animate();


### PR DESCRIPTION
Add a static home page with a Three.js example.

* Modify `index.js` to serve static files from the `public` directory and change the root route to send the `index.html` file.
* Add `public/index.html` with a basic HTML structure, including a script tag for the Three.js library and a `main.js` file, and a `div` element with an `id` of `container`.
* Add `public/main.js` to create a basic Three.js scene with a camera, renderer, and a rotating cube, and append the renderer's DOM element to the `container` div.

